### PR TITLE
CI: add npm Trusted Publisher workflows and security configuration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,8 @@
 # This file defines code ownership for automatic review requests
 
 # Critical workflow files must be reviewed by repository owner
-/.github/CODEOWNERS @azu
 /.github/workflows/release.yml @azu
 /.github/workflows/create-release-pr.yml @azu
+
+# CODEOWNERS file itself requires review to prevent bypassing protections
+/.github/CODEOWNERS @azu

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,13 @@ on:
       - closed
 
 jobs:
-  # Main release job that publishes to npm when a release PR is merged
   release:
     if: |
       github.event.pull_request.merged == true &&
       contains(github.event.pull_request.labels.*.name, 'Type: Release')
     runs-on: ubuntu-latest
     environment: 
-      name: release
+      name: npm
     permissions:
       contents: write
       id-token: write  # OIDC
@@ -26,13 +25,11 @@ jobs:
       package-name: ${{ steps.package.outputs.name }}
       release-url: ${{ steps.create-release.outputs.url }}
     steps:
-      # Checkout the repository code
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           persist-credentials: false
       
-      # Extract package version and name from package.json
       - name: Get package info
         id: package
         run: |
@@ -53,7 +50,6 @@ jobs:
           VERSION: ${{ steps.package.outputs.version }}
       
       
-      # Setup Node.js environment for npm publishing
       - name: Setup Node.js
         if: steps.tag-check.outputs.exists == 'false'
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
@@ -72,7 +68,6 @@ jobs:
         if: steps.tag-check.outputs.exists == 'false'
         run: npm ci
       
-      # Publish package to npm with OIDC authentication and provenance
       - name: Publish to npm with provenance
         if: steps.tag-check.outputs.exists == 'false'
         run: npm publish --access public


### PR DESCRIPTION
- create-release-pr.yml: Creates release PRs with version bump and release notes
- release.yml: Publishes to npm using Trusted Publisher (OIDC) when PR is merged
- CODEOWNERS: Protects critical workflow files from unauthorized changes
- No npm tokens required - uses GitHub OIDC for authentication